### PR TITLE
Sundanese

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Javanese numeral system
 - Cham numeral system
 - Lepcha numeral system
+- Sundanese numeral system
 ## [0.7] - 2025-09-17
 ### Added
 - Nko numeral system

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ It can automatically detect mixed numeral formats in a piece of text and convert
 - Javanese
 - Cham
 - Lepcha
+- Sundanese
 
 ## Issues & bug reports
 

--- a/tests/test_arabic_indic.py
+++ b/tests/test_arabic_indic.py
@@ -42,6 +42,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_balinese.py
+++ b/tests/test_balinese.py
@@ -43,6 +43,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_bengali.py
+++ b/tests/test_bengali.py
@@ -42,6 +42,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_burmese.py
+++ b/tests/test_burmese.py
@@ -42,6 +42,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_cham.py
+++ b/tests/test_cham.py
@@ -43,6 +43,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: CHAM_DIGITS,
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_english.py
+++ b/tests/test_english.py
@@ -50,6 +50,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_gujarati.py
+++ b/tests/test_gujarati.py
@@ -42,6 +42,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_gurmukhi.py
+++ b/tests/test_gurmukhi.py
@@ -43,6 +43,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_hindi.py
+++ b/tests/test_hindi.py
@@ -42,6 +42,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_javanese.py
+++ b/tests/test_javanese.py
@@ -43,6 +43,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: JAVANESE_DIGITS,
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_kannada.py
+++ b/tests/test_kannada.py
@@ -42,6 +42,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_khmer.py
+++ b/tests/test_khmer.py
@@ -43,6 +43,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_lao.py
+++ b/tests/test_lao.py
@@ -42,6 +42,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_lepcha.py
+++ b/tests/test_lepcha.py
@@ -43,6 +43,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: LEPCHA_DIGITS,
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_limbu.py
+++ b/tests/test_limbu.py
@@ -43,6 +43,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_mongolian.py
+++ b/tests/test_mongolian.py
@@ -43,6 +43,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_myanmar_shan.py
+++ b/tests/test_myanmar_shan.py
@@ -43,6 +43,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_new_tai_lue.py
+++ b/tests/test_new_tai_lue.py
@@ -43,6 +43,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_nko.py
+++ b/tests/test_nko.py
@@ -43,6 +43,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_odia.py
+++ b/tests/test_odia.py
@@ -43,6 +43,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_ol_chiki.py
+++ b/tests/test_ol_chiki.py
@@ -43,6 +43,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_persian.py
+++ b/tests/test_persian.py
@@ -43,6 +43,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_saurashtra.py
+++ b/tests/test_saurashtra.py
@@ -43,6 +43,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_sinhala_lith.py
+++ b/tests/test_sinhala_lith.py
@@ -43,6 +43,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_sundanese.py
+++ b/tests/test_sundanese.py
@@ -46,7 +46,7 @@ CONVERSION_CASES = {
 }
 
 
-def test_bengali_digits():
+def test_sundanese_digits():
 
     assert SUNDANESE_DIGITS == xnum.params.SUNDANESE_DIGITS
     assert list(map(int, SUNDANESE_DIGITS)) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]

--- a/tests/test_sundanese.py
+++ b/tests/test_sundanese.py
@@ -1,0 +1,68 @@
+import pytest
+import xnum.params
+from xnum import convert, NumeralSystem
+
+TEST_CASE_NAME = "Sundanese tests"
+SUNDANESE_DIGITS = "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹"
+
+CONVERSION_CASES = {
+    NumeralSystem.ARABIC_INDIC: "٠١٢٣٤٥٦٧٨٩",
+    NumeralSystem.ENGLISH: "0123456789",
+    NumeralSystem.ENGLISH_FULLWIDTH: "０１２３４５６７８９",
+    NumeralSystem.ENGLISH_SUBSCRIPT: "₀₁₂₃₄₅₆₇₈₉",
+    NumeralSystem.ENGLISH_SUPERSCRIPT: "⁰¹²³⁴⁵⁶⁷⁸⁹",
+    NumeralSystem.ENGLISH_DOUBLE_STRUCK: "𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟟𝟠𝟡",
+    NumeralSystem.ENGLISH_BOLD: "𝟎𝟏𝟐𝟑𝟒𝟓𝟔𝟕𝟖𝟗",
+    NumeralSystem.ENGLISH_MONOSPACE: "𝟶𝟷𝟸𝟹𝟺𝟻𝟼𝟽𝟾𝟿",
+    NumeralSystem.ENGLISH_SANS_SERIF: "𝟢𝟣𝟤𝟥𝟦𝟧𝟨𝟩𝟪𝟫",
+    NumeralSystem.ENGLISH_SANS_SERIF_BOLD: "𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵",
+    NumeralSystem.PERSIAN: "۰۱۲۳۴۵۶۷۸۹",
+    NumeralSystem.HINDI: "०१२३४५६७८९",
+    NumeralSystem.BENGALI: "০১২৩৪৫৬৭৮৯",
+    NumeralSystem.THAI: "๐๑๒๓๔๕๖๗๘๙",
+    NumeralSystem.KHMER: "០១២៣៤៥៦៧៨៩",
+    NumeralSystem.BURMESE: "၀၁၂၃၄၅၆၇၈၉",
+    NumeralSystem.TIBETAN: "༠༡༢༣༤༥༦༧༨༩",
+    NumeralSystem.GUJARATI: "૦૧૨૩૪૫૬૭૮૯",
+    NumeralSystem.ODIA: "୦୧୨୩୪୫୬୭୮୯",
+    NumeralSystem.TELUGU: "౦౧౨౩౪౫౬౭౮౯",
+    NumeralSystem.KANNADA: "೦೧೨೩೪೫೬೭೮೯",
+    NumeralSystem.GURMUKHI: "੦੧੨੩੪੫੬੭੮੯",
+    NumeralSystem.LAO: "໐໑໒໓໔໕໖໗໘໙",
+    NumeralSystem.NKO: "߀߁߂߃߄߅߆߇߈߉",
+    NumeralSystem.MONGOLIAN: "᠐᠑᠒᠓᠔᠕᠖᠗᠘᠙",
+    NumeralSystem.SINHALA_LITH: "෦෧෨෩෪෫෬෭෮෯",
+    NumeralSystem.MYANMAR_SHAN: "႐႑႒႓႔႕႖႗႘႙",
+    NumeralSystem.LIMBU: "᥆᥇᥈᥉᥊᥋᥌᥍᥎᥏",
+    NumeralSystem.VAI: "꘠꘡꘢꘣꘤꘥꘦꘧꘨꘩",
+    NumeralSystem.OL_CHIKI: "᱐᱑᱒᱓᱔᱕᱖᱗᱘᱙",
+    NumeralSystem.BALINESE: "᭐᭑᭒᭓᭔᭕᭖᭗᭘᭙",
+    NumeralSystem.NEW_TAI_LUE: "᧐᧑᧒᧓᧔᧕᧖᧗᧘᧙",
+    NumeralSystem.SAURASHTRA: "꣐꣑꣒꣓꣔꣕꣖꣗꣘꣙",
+    NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
+    NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
+    NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: SUNDANESE_DIGITS,
+}
+
+
+def test_bengali_digits():
+
+    assert SUNDANESE_DIGITS == xnum.params.SUNDANESE_DIGITS
+    assert list(map(int, SUNDANESE_DIGITS)) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+
+@pytest.mark.parametrize("target,expected", CONVERSION_CASES.items())
+def test_sundanese_to_other_systems(target, expected):
+
+    assert convert(
+        SUNDANESE_DIGITS,
+        source=NumeralSystem.SUNDANESE,
+        target=target,
+    ) == expected
+
+    assert convert(
+        f"abc {SUNDANESE_DIGITS} abc",
+        source=NumeralSystem.SUNDANESE,
+        target=target,
+    ) == f"abc {expected} abc"

--- a/tests/test_telugu.py
+++ b/tests/test_telugu.py
@@ -43,6 +43,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_thai.py
+++ b/tests/test_thai.py
@@ -43,6 +43,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_tibetan.py
+++ b/tests/test_tibetan.py
@@ -43,6 +43,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/tests/test_vai.py
+++ b/tests/test_vai.py
@@ -43,6 +43,7 @@ CONVERSION_CASES = {
     NumeralSystem.JAVANESE: "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙",
     NumeralSystem.CHAM: "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙",
     NumeralSystem.LEPCHA: "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉",
+    NumeralSystem.SUNDANESE: "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹",
 }
 
 

--- a/xnum/params.py
+++ b/xnum/params.py
@@ -40,6 +40,7 @@ SAURASHTRA_DIGITS = "꣐꣑꣒꣓꣔꣕꣖꣗꣘꣙"
 JAVANESE_DIGITS = "꧐꧑꧒꧓꧔꧕꧖꧗꧘꧙"
 CHAM_DIGITS = "꩐꩑꩒꩓꩔꩕꩖꩗꩘꩙"
 LEPCHA_DIGITS = "᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉"
+SUNDANESE_DIGITS = "᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹"
 
 
 NUMERAL_MAPS = {
@@ -79,6 +80,7 @@ NUMERAL_MAPS = {
     "javanese": JAVANESE_DIGITS,
     "cham": CHAM_DIGITS,
     "lepcha": LEPCHA_DIGITS,
+    "sundanese": SUNDANESE_DIGITS,
 }
 
 ALL_DIGIT_MAPS = {}
@@ -126,6 +128,7 @@ class NumeralSystem(Enum):
     JAVANESE = "javanese"
     CHAM = "cham"
     LEPCHA = "lepcha"
+    SUNDANESE = "sundanese"
     AUTO = "auto"
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
#70 
#### What does this implement/fix? Explain your changes.

#### Any other comments?
In my system (MacOS) I can see the characters in the symbl.cc clearly, unlike compart. For the earlier PRs I used to use compart as the main reference, but in this PR, I will use symbl.cc.

<img width="237" height="359" alt="Image" src="https://github.com/user-attachments/assets/2c23201c-958a-4122-8c1e-a015cd0881b1" />
<img width="978" height="359" alt="Image" src="https://github.com/user-attachments/assets/ac1f6afa-9445-4dbd-b7d3-38e7c5204f7f" />
